### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/orpelp101/e93542e9-7329-4b60-b2a2-2cc171ea0fcc/5497a464-fb9f-43fd-8a15-b2cf974102fa/_apis/work/boardbadge/9f448a8d-f792-410a-b179-84e8702f3e46)](https://dev.azure.com/orpelp101/e93542e9-7329-4b60-b2a2-2cc171ea0fcc/_boards/board/t/5497a464-fb9f-43fd-8a15-b2cf974102fa/Microsoft.RequirementCategory)
 # README


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/orpelp101/e93542e9-7329-4b60-b2a2-2cc171ea0fcc/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.